### PR TITLE
Added RPi.GPIO to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     install_requires=[
-        "evdev"
+        "evdev",
+        "RPi.GPIO",
     ],
     packages=find_packages(
         exclude=[


### PR DESCRIPTION
RPi.GPIO is imported by the core module but not included in package requirements. RPi.GPIO is not included on a clean install.