### PR TITLE
Correct private method call for buzzer property in _Core, seeed_python_rpi/core.py

### DIFF
--- a/seeed_python_rpi/core.py
+++ b/seeed_python_rpi/core.py
@@ -99,7 +99,7 @@ class _Core(board_class):
     @property
     def buzzer(self):
         if hasattr(_Core, 'BUZZER_BRIGHTNESS'):
-            return True if self.read_1st_line_from_file(_Core.BUZZER_BRIGHTNESS) != "0" else False
+            return True if self.__read_1st_line_from_file(_Core.BUZZER_BRIGHTNESS) != "0" else False
         elif hasattr(_Core, 'BUZZER_GPIO_CHIP'):
             chip = gpiod.Chip(_Core.BUZZER_GPIO_CHIP)
             line = chip.find_lines(_Core.BUZZER_GPIO_LINE)


### PR DESCRIPTION
Resolve an AttributeError in the `_Core.buzzer` property by changing the call from `self.read_1st_line_from_file` to `self.__read_1st_line_from_file` in `seeed_python_rpi/core.py`
This fixes the error: AttributeError: '_Core' object has no attribute '_read_1st_line_from_file', which is raised when attempting to get the value of buzzer